### PR TITLE
Add new roadmap item issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-item.md
@@ -1,0 +1,30 @@
+---
+name: 'Roadmap Item'
+about: Create roadmap item for this project
+title: Roadmap Item =description=
+labels: kind/roadmap
+assignees: ''
+---
+
+# O3DE Roadmap Item Template
+
+### When using this template, you do not have to fill out every question below. The questions are there for guidance.
+
+This roadmap item template should be used for any feature that shows in the O3DE public roadmap. The issue communicates the initiative and vision of the SIG.
+
+# ----- DELETE EVERYTHING FROM THE TOP TO THE SUMMARY LINE BELOW WHEN USING TEMPLATE ----- #
+
+### Summary:
+Single paragraph explanation of the roadmap item
+
+### What is the relevance of this feature?
+- What problems does it solves? 
+- Why is this important? 
+- What will it do once completed?
+- Are there any changes or impacts to other features? 
+
+### Tasks
+What tasks are necessary to complete the roadmap item?
+
+### Related Links
+Link to additional informaton such as RFC related to the roadmap item.


### PR DESCRIPTION
The context of the roadmap item can be read here: https://github.com/o3de/sig-release/issues/79.

### Action Needed
Since the template automatically assigns kind/roadmap to the roadmap item issue, please create this label in your SIG repo if it does not exist already once you merge the PR.
1. label name: **kind/roadmap**
2. description: **Categorizes an issue that goes in the O3DE Public Roadmap**

Signed-off-by: Vincent <vincentbiasa6767@gmail.com>