### PR TITLE
Add needs-triage and checklist as a reference

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-item.md
@@ -2,8 +2,9 @@
 name: 'Roadmap Item'
 about: Create roadmap item for this project
 title: Roadmap Item =description=
-labels: kind/roadmap
+labels: kind/roadmap, needs-triage
 assignees: ''
+
 ---
 
 # O3DE Roadmap Item Template
@@ -25,6 +26,8 @@ Single paragraph explanation of the roadmap item
 
 ### Tasks
 What tasks are necessary to complete the roadmap item?
+- [ ] _GitHub issue 1 link_
+- [ ] _GitHub issue 2 link and so on._
 
 ### Related Links
 Link to additional informaton such as RFC related to the roadmap item.

--- a/.github/ISSUE_TEMPLATE/roadmap-item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-item.md
@@ -1,7 +1,7 @@
 ---
 name: 'Roadmap Item'
 about: Create roadmap item for this project
-title: Roadmap: =description=
+title: 'Roadmap: =description='
 labels: kind/roadmap, needs-triage
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/roadmap-item.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-item.md
@@ -1,0 +1,30 @@
+---
+name: 'Roadmap Item'
+about: Create roadmap item for this project
+title: Roadmap Item =description=
+labels: kind/roadmap
+assignees: ''
+---
+
+# O3DE Roadmap Item Template
+
+### When using this template, you do not have to fill out every question below. The questions are there for guidance.
+
+This roadmap item template should be used for any feature that shows in the O3DE public roadmap. The issue communicates the initiative and vision of the SIG.
+
+# ----- DELETE EVERYTHING FROM THE TOP TO THE SUMMARY LINE BELOW WHEN USING TEMPLATE ----- #
+
+### Summary:
+Single paragraph explanation of the roadmap item
+
+### What is the relevance of this feature?
+- What problems does it solves? 
+- Why is this important? 
+- What will it do once completed?
+- Are there any changes or impacts to other features? 
+
+### Tasks
+What tasks are necessary to complete the roadmap item?
+
+### Related Links
+Link to additional informaton such as RFC related to the roadmap item.


### PR DESCRIPTION
Updated the roadmap item template
1. Add a needs-triage label if the roadmap item needs to be triaged. If it's already triaged, then you can remove it.
2. Add a checklist as a reference so the maintainer what use the suggested format to link respective tasks. 

RFC reference: https://github.com/o3de/sig-release/issues/79

# Action Needed
Since the RFC leverage three labels, kind/roadmap, needs-triage, and triage/accepted, please create this label in your SIG repo if it does not exist already once you merge the PR.

### needs-triage
Taken from [O3DE label](https://github.com/o3de/o3de/labels?q=needs-triage)
label name: **needs-triage**
description: **Indicates an issue or PR lacks a `triage/foo` label and requires one**

### triage/accepted
Taken from [O3DE Label](https://github.com/o3de/o3de/labels?q=triage%2Faccepted)
- label name: triage/accepted
- description: Indicates an issue or PR is ready to be actively worked on.

Signed-off-by: Vincent <vincentbiasa6767@gmail.com>